### PR TITLE
Fix broken MIT license link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To address these challenges, contributors have introduced various state-of-the-a
 All models, regardless of the approach used, achieve over 90% accuracy. For more detailed information on each approach, please refer to the contributors' repositories.
 
 
+
 ## License
 
 This project is licensed under the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
Fixes the broken MIT License link.

Closes #36
