### PR TITLE
Fix: Contrastive Loss Logic & Support ResNet50 Dimensions in Encoder

### DIFF
--- a/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/encoder.py
+++ b/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/encoder.py
@@ -1,23 +1,40 @@
 import torch
 from torch import nn
 from huggingface_hub import PyTorchModelHubMixin
+# Assuming these are custom implementations given the specific sequence length comments
 from ResNet import ResNet18, ResNet34, ResNet50
 
-
 class Encoder(nn.Module, PyTorchModelHubMixin):
-    def __init__(self):
+    def __init__(self, model_type='resnet50'):
         super(Encoder, self).__init__()
-        # self.resnet = ResNet18()
-        self.resnet = ResNet50()
-        self.lstm = nn.LSTM(input_size=512, hidden_size=256, num_layers=2, batch_first=True, bidirectional=True)
+        
+        # Select Backbone and determine Feature Size
+        if model_type == 'resnet50':
+            self.resnet = ResNet50()
+            enc_channels = 2048 # ResNet50 standard output
+        else:
+            self.resnet = ResNet18()
+            enc_channels = 512  # ResNet18/34 standard output
+
+        # LSTM Input Size must match Encoder Output
+        self.lstm = nn.LSTM(
+            input_size=enc_channels, 
+            hidden_size=256, 
+            num_layers=2, 
+            batch_first=True, 
+            bidirectional=True
+        )
 
     def forward(self, x):
-        # [batch size, channel(3), height(32), width(100)]
-        resnet_output = self.resnet(x)
-        # [batch size, feature length(512), 1, sequence length(22)]
-        resnet_output = torch.squeeze(resnet_output, dim=2)
-        resnet_output = torch.permute(resnet_output, (0, 2, 1))
-        # [batch size, sequence length, feature length]
-        rnn_output, hidden = self.lstm(resnet_output)
-        # [batch size, sequence length, forward output length + backward output length(256)]
+        features = self.resnet(x)
+        # Instead of strict squeeze, we pool vertical features if H' > 1, 
+        features = features.mean(dim=2) 
+        # Prepare for LSTM (Batch, Seq_Len, Features)
+        # Current: [Batch, Channels, Width] -> Permute to [Batch, Width, Channels]
+        features = features.permute(0, 2, 1)  
+        # Input: [Batch, Width (Seq Len), Channels (2048)]
+        self.lstm.flatten_parameters() # Good practice for memory/speed on GPU
+        rnn_output, hidden = self.lstm(features)
+        
+        # Output: [Batch, Seq Len, 512 (256*2)]
         return rnn_output, hidden


### PR DESCRIPTION
## Description
This PR addresses critical logic errors in the loss function and dimension mismatch issues when switching from ResNet18 to ResNet50.

### 1. Fix: Contrastive Loss Logic
The previous `noise_contrastive_estimation` function contained a bug where the target indices were calculated using an inverse permutation logic that did not align with the shuffled input, leading to incorrect optimization targets. 

**Changes:**
- Removed unnecessary `randperm` shuffling.
- Implemented standard **Symmetric Contrastive Loss** (similar to CLIP/SimCLR).
- Fixed `cosine_similarity` normalization to `dim=-1` to support both 2D and 3D tensors generically.
- Removed hardcoded device transfers (`.to(x.device)`) in favor of direct tensor creation on the correct device.
---
### 2. Fix: Encoder Dimension Mismatch
The `Encoder` was previously hardcoded for ResNet18/34 (512 channels), causing a shape mismatch crash when initializing with `ResNet50` (2048 channels).

**Changes:**
- Updated LSTM `input_size` to dynamically handle ResNet50's 2048 channel output.
- Replaced `torch.squeeze(dim=2)` with `torch.mean(dim=2)`. This prevents crashes if the feature map height is not exactly 1 and makes the model robust to varying input image sizes.
- Added `self.lstm.flatten_parameters()` to suppress warnings and improve performance on CUDA.
---
## Checklist
- [x] Verified loss calculation logic against standard implementations.
- [x] Verified Encoder forward pass shapes with ResNet50 backbone.