### PR TITLE
docs: add missing torchaudio dependency to requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 RenAIssance_Transformer_OCR_Utsav_Rai/weights
 RenAIssance_Transformer_OCR_Utsav_Rai/models
 RenAIssance_Transformer_OCR_Utsav_Rai/quantized_model
+*.pyc
+/venv

--- a/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/requirements.txt
+++ b/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/requirements.txt
@@ -8,3 +8,4 @@ torchmetrics==1.2.1
 --index-url https://download.pytorch.org/whl/cu124
 torch==2.4.1+cu124
 torchvision==0.19.1+cu124
+torchaudio==2.4.1+cu124

--- a/RenAIssance_SyntheticImageGeneration_Saarthak_Gupta/.gitignore
+++ b/RenAIssance_SyntheticImageGeneration_Saarthak_Gupta/.gitignore
@@ -1,3 +1,7 @@
+venv/
+.vscode/
+__pycache__/
+*.pyc
 data/GAN-DATA/2_splitted
 data/GAN-DATA/3_processed
 data/GAN-DATA/4_bounding_boxes


### PR DESCRIPTION
Added torchaudio==2.4.1+cu124 to requirements.txt to ensure compatibility with the specified torch and torchvision versions for CUDA 12.4 environments. This prevents dependency conflicts during setup