### PR TITLE
docs: remove duplicate line and fix typos in README

### DIFF
--- a/RenAIssance_Transformer_OCR_Utsav_Rai/README.md
+++ b/RenAIssance_Transformer_OCR_Utsav_Rai/README.md
@@ -241,8 +241,7 @@ To start the application:
 4. **Run OCR**: After line segmentation, click "Run OCR" to extract text from the detected regions. The OCR output is displayed line-by-line.
 5. **Navigate Pages**: Use the "Next PDF Page" and "Previous PDF Page" buttons to move through the document.
 6. **Save Processed Images**: You can save the left or right page as an image with detected bounding boxes.
-
-This tool is designed to make document digitization easier by allowing interactive control over processing and real-time feedback on the results.
+   
 ## Usage
 
 ### Data Preparation
@@ -309,7 +308,7 @@ python test.py
 BLEU = 0.92
 ## Acknowledgements
 
-This project is supported by the [HumanAI Foundation](https://humanai.foundation/) and Google Summer of Code 2024 and 2025. Detailed documentation and a journey of this project during 2024 can be found in the [blog post 1](https://utsavrai.substack.com/p/a-journey-into-historical-text-recognition) & [blag post 2](https://utsavrai.substack.com/p/decoding-history-advancing-text-recognition). For 2025 refer [2025 midterm blog](https://utsavrai.substack.com/p/efficient-transformer-based-ocr-for?r=3ypuho), [2025 Finalterm blog](https://open.substack.com/pub/utsavrai/p/containerised-quantised-transformer?utm_campaign=post-expanded-share&utm_medium=web).
+This project is supported by the [HumanAI Foundation](https://humanai.foundation/) and Google Summer of Code 2024 and 2025. Detailed documentation and a journey of this project during 2024 can be found in the [blog post 1](https://utsavrai.substack.com/p/a-journey-into-historical-text-recognition) & [blog post 2](https://utsavrai.substack.com/p/decoding-history-advancing-text-recognition). For 2025 refer [2025 midterm blog](https://utsavrai.substack.com/p/efficient-transformer-based-ocr-for?r=3ypuho), [2025 finalterm blog](https://open.substack.com/pub/utsavrai/p/containerised-quantised-transformer?utm_campaign=post-expanded-share&utm_medium=web).
 
 ## License
 


### PR DESCRIPTION
1. Remove repeated App Usage description line from README.
2. Fix “blag post 2” typo to “blog post 2”.
3. Update “2025 Finalterm blog” wording to “2025 finalterm blog”.