### PR TITLE
Remove unused num_classes parameter from ResNet18 and ResNet34

### DIFF
--- a/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/ResNet.py
+++ b/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/ResNet.py
@@ -36,7 +36,7 @@ class BasicBlock(nn.Module):
 
 
 class ResNet18(nn.Module):
-    def __init__(self, num_classes=1000):
+    def __init__(self):
         super(ResNet18, self).__init__()
         self.in_channels = 64
 
@@ -80,7 +80,7 @@ class ResNet18(nn.Module):
 
 
 class ResNet34(nn.Module):
-    def __init__(self, num_classes=1000):
+    def __init__(self):
         super(ResNet34, self).__init__()
         self.in_channels = 64
 


### PR DESCRIPTION
Both `ResNet18` and `ResNet34` constructors accept a `num_classes` parameter (defaulting to 1000), but it is never used anywhere in the class. These models are used purely as feature extractors in `encoder.py`, where they are instantiated with no arguments. The classification head was never implemented, so `num_classes` is dead code.

This removes the unused parameter to keep the interface clean and avoid confusion.

Related: #71