### PR TITLE
Make Encoder backbone configurable (ResNet18/34/50)

### DIFF
--- a/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/encoder.py
+++ b/RenAIssance_SelfSupervisedLearning_OCR_YukinoriYamamoto/encoder.py
@@ -3,13 +3,32 @@ from torch import nn
 from huggingface_hub import PyTorchModelHubMixin
 from ResNet import ResNet18, ResNet34, ResNet50
 
+BACKBONE_REGISTRY = {
+    "resnet18": (ResNet18, 512),
+    "resnet34": (ResNet34, 512),
+    "resnet50": (ResNet50, 512),
+}
+
 
 class Encoder(nn.Module, PyTorchModelHubMixin):
-    def __init__(self):
+    def __init__(self, backbone="resnet50"):
         super(Encoder, self).__init__()
-        # self.resnet = ResNet18()
-        self.resnet = ResNet50()
-        self.lstm = nn.LSTM(input_size=512, hidden_size=256, num_layers=2, batch_first=True, bidirectional=True)
+
+        if backbone not in BACKBONE_REGISTRY:
+            raise ValueError(
+                f"Unknown backbone '{backbone}'. "
+                f"Choose from: {list(BACKBONE_REGISTRY.keys())}"
+            )
+
+        resnet_cls, lstm_input_size = BACKBONE_REGISTRY[backbone]
+        self.resnet = resnet_cls()
+        self.lstm = nn.LSTM(
+            input_size=lstm_input_size,
+            hidden_size=256,
+            num_layers=2,
+            batch_first=True,
+            bidirectional=True,
+        )
 
     def forward(self, x):
         # [batch size, channel(3), height(32), width(100)]


### PR DESCRIPTION
Currently the Encoder class hard-codes ResNet50 as the backbone, and switching to ResNet18 or ResNet34 means commenting/uncommenting lines. This adds a `backbone` argument so users can pick which ResNet variant to use at init time:

`python
encoder = Encoder(backbone="resnet18")
encoder = Encoder(backbone="resnet34")
encoder = Encoder()  # defaults to resnet50
`  

A simple registry maps each backbone name to its class and output channel size, so the LSTM input dimension is always set correctly.

Backward compatible - calling `Encoder()` with no args still gives ResNet50.

Closes #73