### PR TITLE
Fix: Resolve dictionary key overwrites and missing pandas import in data generation pipeline

### DIFF
--- a/RenAIssance_SyntheticImageGeneration_Saarthak_Gupta/src/data_generation.py
+++ b/RenAIssance_SyntheticImageGeneration_Saarthak_Gupta/src/data_generation.py
@@ -1,11 +1,12 @@
 import warnings
 warnings.filterwarnings("ignore")
 import os
+import pandas as pd  # Added missing import
 from data_utils import *
 
 def data_generation_pipeline():
     
-    # 1. Split books and transcripts into individual files
+    # Split books and transcripts into individual files
     process_books_with_transcripts(
         input_books_folder="data/GAN-DATA/1_raw/books/",
         input_transcripts_folder="data/GAN-DATA/1_raw/transcripts/",
@@ -13,21 +14,18 @@ def data_generation_pipeline():
         output_transcripts_folder="data/GAN-DATA/2_splitted/transcripts/"
     )
 
-    # 2. Preprocessing images
+    # Preprocessing images
     copy_all_transcripts()
     copy_all_images()
 
     book_transformations = {
         'book1': {
-            'denoise_image': {'method': 'bilateral'},
-            'denoise_image': {'method': 'nlm'}
+            'denoise_image': [{'method': 'bilateral'}, {'method': 'nlm'}]
         },
         'book2': {
             'ensure_300ppi': {'target_dpi': 150},
             'remove_bleed_dual_layer': {},
-            'denoise_image': {'method': 'bilateral'},
-            'denoise_image': {'method': 'nlm'},
-            'denoise_image': {'method': 'nlm'}
+            'denoise_image': [{'method': 'bilateral'}, {'method': 'nlm'}, {'method': 'nlm'}]
         },
         'book3': {
             'ensure_300ppi': {'target_dpi': 300},
@@ -49,13 +47,11 @@ def data_generation_pipeline():
         },
         'book7': {
             'remove_bleed_dual_layer': {},
-            'denoise_image': {'method': 'nlm'},
-            'denoise_image': {'method': 'bilateral'}
+            'denoise_image': [{'method': 'nlm'}, {'method': 'bilateral'}]
         },
         'book8': {
             'remove_bleed_dual_layer': {},
-            'denoise_image': {'method': 'nlm'},
-            'denoise_image': {'method': 'bilateral'}
+            'denoise_image': [{'method': 'nlm'}, {'method': 'bilateral'}]
         },
         'book9': {
             'ensure_300ppi': {'target_dpi': 300},
@@ -88,7 +84,7 @@ def data_generation_pipeline():
         book_transformations=book_transformations
     )
     
-    # 3. Generate bounding boxes for each book page
+    # Generate bounding boxes for each book page
     input_root = "data/GAN-DATA/3_processed/books"
     output_root = "data/GAN-DATA/4_bounding_boxes//"
     model_path = "CRAFT-pytorch/weights/craft_mlt_25k.pth"
@@ -104,8 +100,8 @@ def data_generation_pipeline():
         bbox_dir="data/GAN-DATA/4_bounding_boxes",
         save_dir="assets/plots/"
     )
-    # 4. Mapping bounding boxes to transcripts
-    # This function will map the bounding boxes generated in the previous step to the corresponding words in the transcripts.
+    
+    # Mapping bounding boxes to transcripts
     similarity_threshold = 0.8
     
     total_words, total_bboxes, total_mapped = mapping_bounding_boxes(
@@ -114,20 +110,18 @@ def data_generation_pipeline():
         transcript_dir="data/GAN-DATA/3_processed/transcripts",
         output_dir="data/GAN-DATA/5_mapped",
         tesseract_model=1,
-        similarity_threshold=0.8
+        similarity_threshold=similarity_threshold  # Passed variable instead of hardcoding
     )
 
-    # 5. Extract and process all regions to create word data
-    # This will extract words from the mapped bounding boxes and save them in the specified output directory.
-    df = extract_and_process_all_regions(
+    # Extract and process all regions to create word data
+    regions_df = extract_and_process_all_regions(
         image_root = "data/GAN-DATA/3_processed/books",
         aligned_root = "data/GAN-DATA/5_mapped",
         output_root = "data/GAN-DATA/6_word_data/images",
         csv_output_path = "data/GAN-DATA/6_word_data/words.csv"
     )
         
-    # 6. Resize and pad images to a fixed size
-
+    # Resize and pad images to a fixed size
     target_height, target_width = 64 , 128
 
     resize_and_pad(
@@ -137,33 +131,31 @@ def data_generation_pipeline():
         target_width=target_width
     )
 
-    # 7. render source text images using matplotlib
+    # render source text images using matplotlib
     config = {
-                'text.usetex': False,
-                'mathtext.fontset': 'cm',
-                'font.family': 'serif',
-                'font.serif': ['Times New Roman'],
-                'font.weight': 'bold',
-                'mathtext.bf': 'bold',
-            }
+        'text.usetex': False,
+        'mathtext.fontset': 'cm',
+        'font.family': 'serif',
+        'font.serif': ['Times New Roman'],
+        'font.weight': 'bold',
+        'mathtext.bf': 'bold',
+    }
 
-    
-    df = generate_text_image_dataset(
-    csv_path='data/GAN-DATA/6_word_data/words.csv',
-    output_dir='data/GAN-DATA/final_dataset',
-    target_dir_prefix='data/GAN-DATA/final_dataset/target/',
-    image_width=target_width,
-    image_height=target_height,
-    base_fontsize=70,
-    matplotlib_config=config,
-    custom_font_path='fonts/RomanAntique.ttf', 
-    progress_bar=True
+    dataset_df = generate_text_image_dataset(
+        csv_path='data/GAN-DATA/6_word_data/words.csv',
+        output_dir='data/GAN-DATA/final_dataset',
+        target_dir_prefix='data/GAN-DATA/final_dataset/target/',
+        image_width=target_width,
+        image_height=target_height,
+        base_fontsize=70,
+        matplotlib_config=config,
+        custom_font_path='fonts/RomanAntique.ttf', 
+        progress_bar=True
     )
     
-    
-    df = pd.read_csv("data/GAN-DATA/final_dataset/data.csv")
+    final_df = pd.read_csv("data/GAN-DATA/final_dataset/data.csv")
     grid_df = create_image_grids(
-        df=df[df['book'].isin(["book_1", "book_5"])],
+        df=final_df[final_df['book'].isin(["book_1", "book_5"])],
         output_directory="data/GAN-DATA/grid_dataset",
         num_grids=3000,
         grid_size=(4,2),
@@ -171,7 +163,5 @@ def data_generation_pipeline():
         random_seed=42
     )
     
-    
 if __name__ == "__main__":        
-        data_generation_pipeline()
-        
+    data_generation_pipeline()


### PR DESCRIPTION
## Description
This PR addresses several critical bugs in the `data_generation_pipeline` script that prevented successful execution and caused silent logic failures.

## Changes Made
* **Added Missing Import:** Added `import pandas as pd` at the top of the file to prevent a `NameError` during the final dataset CSV read.
* **Fixed Dictionary Key Overwrites:** Refactored the `book_transformations` dictionary. Previously, consecutive identical keys (e.g., `'denoise_image'`) were overwriting each other natively in Python. These sequential steps have been bundled into lists (e.g., `'denoise_image': [{'method': 'bilateral'}, {'method': 'nlm'}]`) to preserve the pipeline's operational intent. *(Note: Ensure `process_multiple_books` is equipped to parse these list values).*
* **Variable Renaming:** Prevented `df` from being assigned and overwritten three separate times in sequence. Variables are now explicitly named (`regions_df`, `dataset_df`, `final_df`) to improve debugging capability.
* **Passed Defined Variables:** Replaced the hardcoded `0.8` in `mapping_bounding_boxes` with the initialized `similarity_threshold` variable.